### PR TITLE
chore: drop pyproject build config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+# Build configuration is defined here directly. The previous
+# ``pyproject.toml`` has been removed to avoid triggering extra
+# build-time dependencies (e.g. ``typing``) in environments such as
+# Buildroot.
 [metadata]
 name = PGPy
 version = 0.6.0


### PR DESCRIPTION
## Summary
- avoid requiring typing by removing pyproject.toml
- document Buildroot-friendly build setup in setup.cfg

## Testing
- `pytest` *(fails: Brainpool curve tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b505442f5883228a10fa7c66d1e47f