### PR TITLE
Bump version to 0.6.1 for cryptography 45.x compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = PGPy
-version = 0.6.0
+version = 0.6.1
 author = Michael Greene
 author_email = mgreene@securityinnovation.com
 maintainer = Security Innovation


### PR DESCRIPTION
## Problem

`cryptography>=45` added a required abstract method `group_order` to `ec.EllipticCurve`. pypi's PGPy 0.6.0 defines brainpool curve classes that inherit from `ec.EllipticCurve` without implementing this property, causing:

```
TypeError: Can't instantiate abstract class BrainpoolP512R1 without an implementation for abstract method 'group_order'
```

This fork already fixes the issue by using `CurveDescriptor` (which doesn't inherit from `ec.EllipticCurve`). However, when pip has pgpy 0.6.0 cached or pre-installed, it may skip reinstalling from the URL since versions match.

## Fix

Bump version to **0.6.1** so pip always installs/updates to this fork over pypi's 0.6.0.

## Testing

All brainpool curve tests pass with cryptography 45.0.5:
- `test_private_key_export_with_subkeys[brainpoolp256r1]` ✅
- `test_private_key_export_with_subkeys[brainpoolp384r1]` ✅  
- `test_private_key_export_with_subkeys[brainpoolp512r1]` ✅
- All 71 bip85/pgp tests pass ✅

## Follow-up

After this PR merges, update seedsigner's `requirements.txt` to point to the new commit SHA.